### PR TITLE
feature(frontend): add create post page and profile page

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -3,7 +3,8 @@ import LoginPage from './pages/LoginPage'
 import RegisterPage from './pages/RegisterPage'
 import FeedPage from './pages/FeedPage'
 import PostDetailPage from './pages/PostDetailPage'
-
+import CreatePostPage from './pages/CreatePostPage'
+import ProfilePage from './pages/ProfilePage'
 
 function NotFound() {
     return <h1 className="text-3xl font-bold p-8">404 — Página não encontrada</h1>
@@ -15,7 +16,9 @@ export default function App() {
             <Route path="/" element={<FeedPage />} />
             <Route path="/login" element={<LoginPage />} />
             <Route path="/register" element={<RegisterPage />} />
+            <Route path="/posts/new" element={<CreatePostPage />} />
             <Route path="/posts/:id" element={<PostDetailPage />} />
+            <Route path="/profile" element={<ProfilePage />} />
             <Route path="*" element={<NotFound />} />
         </Routes>
     )

--- a/app/src/pages/CreatePostPage.tsx
+++ b/app/src/pages/CreatePostPage.tsx
@@ -1,0 +1,186 @@
+import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import api from '../api/axios'
+
+interface Community {
+    id: number
+    name: string
+    description: string
+}
+
+interface PageResponse<T> {
+    content: T[]
+}
+
+export default function CreatePostPage() {
+    const navigate = useNavigate()
+    const isLoggedIn = !!localStorage.getItem('token')
+
+    const [title, setTitle] = useState('')
+    const [content, setContent] = useState('')
+    const [communityId, setCommunityId] = useState<number | ''>('')
+    const [communities, setCommunities] = useState<Community[]>([])
+    const [loading, setLoading] = useState(false)
+    const [errors, setErrors] = useState<Record<string, string>>({})
+
+    useEffect(() => {
+        if (!isLoggedIn) {
+            navigate('/login')
+            return
+        }
+        async function fetchCommunities() {
+            try {
+                const res = await api.get<PageResponse<Community>>('/api/communities', {
+                    params: { page: 0, size: 100 },
+                })
+                setCommunities(res.data.content)
+            } catch {}
+        }
+        fetchCommunities()
+    }, [])
+
+    async function handleSubmit(e: React.FormEvent) {
+        e.preventDefault()
+        setErrors({})
+
+        const localErrors: Record<string, string> = {}
+        if (!title.trim()) localErrors.title = 'Título é obrigatório'
+        if (!content.trim()) localErrors.content = 'Conteúdo é obrigatório'
+        if (!communityId) localErrors.communityId = 'Selecione uma comunidade'
+        if (Object.keys(localErrors).length > 0) {
+            setErrors(localErrors)
+            return
+        }
+
+        setLoading(true)
+        try {
+            const res = await api.post('/api/posts', {
+                title: title.trim(),
+                content: content.trim(),
+                communityId,
+            })
+            navigate(`/posts/${res.data.id}`)
+        } catch (err: any) {
+            const data = err.response?.data
+            if (data?.errors) {
+                setErrors(data.errors)
+            } else if (data?.error) {
+                setErrors({ form: data.error })
+            } else {
+                setErrors({ form: 'Erro ao criar post. Tente novamente.' })
+            }
+        } finally {
+            setLoading(false)
+        }
+    }
+
+    return (
+        <div className="min-h-screen bg-gray-100">
+            <div className="max-w-2xl mx-auto py-8 px-4">
+
+                <button
+                    onClick={() => navigate('/')}
+                    className="text-sm text-blue-600 hover:underline mb-6 inline-block"
+                >
+                    ← Voltar ao feed
+                </button>
+
+                <div className="bg-white border border-gray-200 rounded-lg p-6">
+                    <h1 className="text-xl font-bold text-gray-900 mb-6">Criar novo post</h1>
+
+                    {errors.form && (
+                        <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-2 rounded mb-4 text-sm">
+                            {errors.form}
+                        </div>
+                    )}
+
+                    <form onSubmit={handleSubmit} className="flex flex-col gap-5">
+
+                        <div>
+                            <label className="block text-sm font-medium text-gray-700 mb-1">
+                                Comunidade
+                            </label>
+                            <select
+                                value={communityId}
+                                onChange={e => setCommunityId(Number(e.target.value))}
+                                className={`w-full border rounded px-3 py-2 text-sm bg-white focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+                                    errors.communityId ? 'border-red-400' : 'border-gray-300'
+                                }`}
+                            >
+                                <option value="">Selecione uma comunidade...</option>
+                                {communities.map(c => (
+                                    <option key={c.id} value={c.id}>
+                                        r/{c.name}
+                                    </option>
+                                ))}
+                            </select>
+                            {errors.communityId && (
+                                <p className="text-xs text-red-500 mt-1">{errors.communityId}</p>
+                            )}
+                        </div>
+
+                        <div>
+                            <label className="block text-sm font-medium text-gray-700 mb-1">
+                                Título
+                            </label>
+                            <input
+                                type="text"
+                                value={title}
+                                onChange={e => setTitle(e.target.value)}
+                                maxLength={300}
+                                placeholder="Dê um título ao seu post..."
+                                className={`w-full border rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+                                    errors.title ? 'border-red-400' : 'border-gray-300'
+                                }`}
+                            />
+                            <div className="flex justify-between mt-1">
+                                {errors.title ? (
+                                    <p className="text-xs text-red-500">{errors.title}</p>
+                                ) : (
+                                    <span />
+                                )}
+                                <span className="text-xs text-gray-400">{title.length}/300</span>
+                            </div>
+                        </div>
+
+                        <div>
+                            <label className="block text-sm font-medium text-gray-700 mb-1">
+                                Conteúdo
+                            </label>
+                            <textarea
+                                value={content}
+                                onChange={e => setContent(e.target.value)}
+                                placeholder="Escreva seu post aqui..."
+                                rows={8}
+                                className={`w-full border rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none ${
+                                    errors.content ? 'border-red-400' : 'border-gray-300'
+                                }`}
+                            />
+                            {errors.content && (
+                                <p className="text-xs text-red-500 mt-1">{errors.content}</p>
+                            )}
+                        </div>
+
+                        <div className="flex justify-end gap-3 pt-2">
+                            <button
+                                type="button"
+                                onClick={() => navigate('/')}
+                                className="px-4 py-2 text-sm text-gray-700 border border-gray-300 rounded hover:bg-gray-50"
+                            >
+                                Cancelar
+                            </button>
+                            <button
+                                type="submit"
+                                disabled={loading}
+                                className="px-5 py-2 text-sm bg-blue-600 text-white rounded font-medium hover:bg-blue-700 disabled:opacity-50"
+                            >
+                                {loading ? 'Publicando...' : 'Publicar post'}
+                            </button>
+                        </div>
+
+                    </form>
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/app/src/pages/ProfilePage.tsx
+++ b/app/src/pages/ProfilePage.tsx
@@ -1,0 +1,150 @@
+import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import api from '../api/axios'
+import type { UserResponse } from '../types/auth'
+import type { Post, PageResponse } from '../types/post'
+import PostCard from '../components/PostCard'
+import { formatDate } from '../utils/formatDate'
+
+export default function ProfilePage() {
+    const navigate = useNavigate()
+    const isLoggedIn = !!localStorage.getItem('token')
+
+    const [user, setUser] = useState<UserResponse | null>(null)
+    const [posts, setPosts] = useState<Post[]>([])
+    const [loadingUser, setLoadingUser] = useState(true)
+    const [loadingPosts, setLoadingPosts] = useState(true)
+
+    useEffect(() => {
+        if (!isLoggedIn) {
+            navigate('/login')
+            return
+        }
+        fetchUser()
+    }, [])
+
+    async function fetchUser() {
+        try {
+            const res = await api.get<UserResponse>('/api/users/me')
+            setUser(res.data)
+            fetchPosts(res.data.username)
+        } catch {
+            navigate('/login')
+        } finally {
+            setLoadingUser(false)
+        }
+    }
+
+    async function fetchPosts(username: string) {
+        try {
+            const res = await api.get<PageResponse<Post>>('/api/posts', {
+                params: { page: 0, size: 100, sort: 'date' },
+            })
+            const userPosts = res.data.content.filter(
+                p => p.author.username === username
+            )
+            setPosts(userPosts)
+        } catch {
+        } finally {
+            setLoadingPosts(false)
+        }
+    }
+
+    function handleLogout() {
+        localStorage.removeItem('token')
+        localStorage.removeItem('username')
+        localStorage.removeItem('role')
+        navigate('/login')
+    }
+
+    if (loadingUser) {
+        return (
+            <div className="min-h-screen bg-gray-100 flex items-center justify-center">
+                <p className="text-gray-400">Carregando perfil...</p>
+            </div>
+        )
+    }
+
+    if (!user) return null
+
+    return (
+        <div className="min-h-screen bg-gray-100">
+            <div className="max-w-2xl mx-auto py-8 px-4">
+
+                <button
+                    onClick={() => navigate('/')}
+                    className="text-sm text-blue-600 hover:underline mb-6 inline-block"
+                >
+                    ← Voltar ao feed
+                </button>
+
+                <div className="bg-white border border-gray-200 rounded-lg p-6 mb-6">
+                    <div className="flex items-start justify-between">
+                        <div className="flex items-center gap-4">
+                            <div className="w-14 h-14 rounded-full bg-blue-600 flex items-center justify-center text-white text-xl font-bold select-none">
+                                {user.username.charAt(0).toUpperCase()}
+                            </div>
+                            <div>
+                                <h1 className="text-lg font-bold text-gray-900">
+                                    u/{user.username}
+                                </h1>
+                                <p className="text-sm text-gray-500">{user.email}</p>
+                                <div className="flex items-center gap-2 mt-1">
+                                    <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${
+                                        user.role === 'ADMIN'
+                                            ? 'bg-red-100 text-red-700'
+                                            : 'bg-blue-100 text-blue-700'
+                                    }`}>
+                                        {user.role === 'ADMIN' ? '👑 Admin' : '👤 Usuário'}
+                                    </span>
+                                    <span className="text-xs text-gray-400">
+                                        Membro desde {formatDate(user.createdAt)}
+                                    </span>
+                                </div>
+                            </div>
+                        </div>
+
+                        <button
+                            onClick={handleLogout}
+                            className="text-sm text-gray-500 border border-gray-300 px-3 py-1.5 rounded hover:bg-gray-50 hover:text-red-600 transition"
+                        >
+                            Sair
+                        </button>
+                    </div>
+                </div>
+
+                <div>
+                    <h2 className="text-sm font-semibold text-gray-700 mb-3">
+                        {loadingPosts
+                            ? 'Carregando posts...'
+                            : `${posts.length} post${posts.length !== 1 ? 's' : ''} publicado${posts.length !== 1 ? 's' : ''}`
+                        }
+                    </h2>
+
+                    {!loadingPosts && posts.length === 0 && (
+                        <div className="bg-white border border-gray-200 rounded-lg p-8 text-center">
+                            <p className="text-gray-400 text-sm">Você ainda não publicou nenhum post.</p>
+                            <button
+                                onClick={() => navigate('/posts/new')}
+                                className="mt-3 text-sm text-blue-600 hover:underline"
+                            >
+                                Criar primeiro post →
+                            </button>
+                        </div>
+                    )}
+
+                    {loadingPosts && (
+                        <p className="text-center text-gray-400 text-sm mt-6">Carregando...</p>
+                    )}
+
+                    <div className="flex flex-col gap-3">
+                        {posts.map(post => (
+                            <PostCard key={post.id} post={post} />
+                        ))}
+                    </div>
+                </div>
+
+            </div>
+        </div>
+    )
+}


### PR DESCRIPTION
## O que foi feito
Implementação das issues **#24** e **#25** — Página de criação de post e página de perfil do usuário.

## Mudanças
* `pages/CreatePostPage.tsx` — página `/posts/new` com formulário de criação de post
* `pages/ProfilePage.tsx` — página `/profile` com dados do usuário e histórico de posts
* `App.tsx` — rotas `/posts/new` e `/profile` adicionadas

## Critérios de aceitação

- [x]  Página `/posts/new` com formulário de criação (título, conteúdo, seleção de comunidade)
- [x]  Rota `/posts/new` protegida — redireciona para `/login` se não autenticado
- [x]  Exibe erros de validação retornados pela API e validação local dos campos
- [x]  Após criar post, redireciona para o detalhe do post criado
- [x]  Página `/profile` exibe dados do usuário logado (username, email, role, data de cadastro)
- [x]  Página `/profile` lista os posts publicados pelo usuário
- [x]  Rota `/profile` protegida — redireciona para `/login` se não autenticado
- [x]  Botão de logout disponível na página de perfil

## Testado
* Acesso sem login redireciona para `/login` em ambas as rotas
* Comunidades carregam corretamente no select da criação de post
* Validação local bloqueia envio com campos vazios
* Erros da API exibidos corretamente no formulário
* Post criado com sucesso redireciona para `/posts/:id`
* Perfil exibe dados corretos do usuário autenticado
* Lista de posts do usuário filtrada corretamente
* Logout limpa localStorage e redireciona para `/login`

Closes #24
Closes #25 
  